### PR TITLE
Added rsconnect folder to be tracked by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,3 @@ vignettes/*.pdf
 *.knit.md
 # R Environment Variables
 .Renviron
-# RSC Connection files
-*.dcf
-rsconnect


### PR DESCRIPTION
Validated that `rsconnect` folder allows us to have multiple people push to the same project in Posit Connect. Tested with Farshad using `test_transfer` and confirmed no confidential info is in the `rsconnect` folder. Closes #22 